### PR TITLE
Update .babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "stage": 0
+  "presets": ["stage-0"]
 }


### PR DESCRIPTION
Fixes error message: "Module build failed: ReferenceError: [BABEL]...Using removed Babel 5 option"

```
Module build failed: ReferenceError: [BABEL]
c:\www\project\node_modules\section-iterator\dist\sectionIterator.js:
Using removed Babel 5 option: c:\www\project\node_modules\section-iterator\.babelrc.stage
Check out the corresponding stage-x presets http://babeljs.io/docs/plugins/#presets
```
